### PR TITLE
Fix unused parameter maxAttempts

### DIFF
--- a/src/android/Args.java
+++ b/src/android/Args.java
@@ -38,6 +38,18 @@ public class Args {
         return defaultValue;
     }
 
+    public Integer getInteger(String name, Integer defaultValue) {
+        try {
+            if (getArgsObject().optString(name) != null
+                    && !getArgsObject().optString(name).isEmpty()){
+                return getArgsObject().getInt(name);
+            }
+        } catch (JSONException e) {
+            Log.e(TAG, "Can't parse '" + name + "'. Default will be used.", e);
+        }
+        return defaultValue;
+    }
+
     private JSONObject getArgsObject() throws JSONException {
         if (this.argsObject != null) {
             return this.argsObject;

--- a/src/android/Args.java
+++ b/src/android/Args.java
@@ -40,8 +40,7 @@ public class Args {
 
     public Integer getInteger(String name, Integer defaultValue) {
         try {
-            if (getArgsObject().optString(name) != null
-                    && !getArgsObject().optString(name).isEmpty()){
+            if (getArgsObject().has(name)){
                 return getArgsObject().getInt(name);
             }
         } catch (JSONException e) {

--- a/src/android/BiometricActivity.java
+++ b/src/android/BiometricActivity.java
@@ -37,6 +37,7 @@ public class BiometricActivity extends AppCompatActivity {
         if (savedInstanceState != null) {
             return;
         }
+        
 
         mPromptInfo = new PromptInfo.Builder(getIntent().getExtras()).build();
         if(numFailedAttempts >= mPromptInfo.getMaxAttempts()) {

--- a/src/android/PluginError.java
+++ b/src/android/PluginError.java
@@ -10,7 +10,7 @@ public enum PluginError {
     BIOMETRIC_PIN_OR_PATTERN_DISMISSED(-109),
     BIOMETRIC_SCREEN_GUARD_UNSECURED(-110,
             "Go to 'Settings -> Security -> Screenlock' to set up a lock screen"),
-    BIOMETRIC_LOCKED_OUT(-111),
+    BIOMETRIC_LOCKED_OUT(-111, "Too many failed attempts. Try again later."),
     BIOMETRIC_LOCKED_OUT_PERMANENT(-112),
     BIOMETRIC_NO_SECRET_FOUND(-113),
     BIOMETRIC_ARGS_PARSING_FAILED(-115);

--- a/src/android/PromptInfo.java
+++ b/src/android/PromptInfo.java
@@ -10,6 +10,7 @@ class PromptInfo {
     private static final String TITLE = "title";
     private static final String SUBTITLE = "subtitle";
     private static final String DESCRIPTION = "description";
+    private static final String MAX_ATTEMPTS = "maxAttempts";
     private static final String FALLBACK_BUTTON_TITLE = "fallbackButtonTitle";
     private static final String CANCEL_BUTTON_TITLE = "cancelButtonTitle";
     private static final String CONFIRMATION_REQUIRED = "confirmationRequired";
@@ -36,6 +37,8 @@ class PromptInfo {
     String getDescription() {
         return bundle.getString(DESCRIPTION);
     }
+
+    Integer getMaxAttempts(){ return bundle.getInt(MAX_ATTEMPTS); }
 
     boolean isDeviceCredentialAllowed() {
         return !bundle.getBoolean(DISABLE_BACKUP);
@@ -72,6 +75,7 @@ class PromptInfo {
         private String title;
         private String subtitle = null;
         private String description = null;
+        private Integer maxAttempts = 5;
         private String fallbackButtonTitle = "Use backup";
         private String cancelButtonTitle = "Cancel";
         private boolean confirmationRequired = true;
@@ -103,6 +107,7 @@ class PromptInfo {
             bundle.putString(SUBTITLE, this.subtitle);
             bundle.putString(TITLE, this.title);
             bundle.putString(DESCRIPTION, this.description);
+            bundle.putInt(MAX_ATTEMPTS, this.maxAttempts);
             bundle.putString(FALLBACK_BUTTON_TITLE, this.fallbackButtonTitle);
             bundle.putString(CANCEL_BUTTON_TITLE, this.cancelButtonTitle);
             bundle.putString(SECRET, this.secret);
@@ -123,6 +128,7 @@ class PromptInfo {
             title = args.getString(TITLE, title);
             subtitle = args.getString(SUBTITLE, subtitle);
             description = args.getString(DESCRIPTION, description);
+            maxAttempts = args.getInteger(MAX_ATTEMPTS, maxAttempts);
             fallbackButtonTitle = args.getString(FALLBACK_BUTTON_TITLE, "Use Backup");
             cancelButtonTitle = args.getString(CANCEL_BUTTON_TITLE, "Cancel");
             confirmationRequired = args.getBoolean(CONFIRMATION_REQUIRED, confirmationRequired);


### PR DESCRIPTION
<!-- Thank you for contributing -->

# Description
Added missing parameter "maxAttempts" that allows the user to configure how many failed attempts should be possible before the plugin blocks the Biometric API.

# How did you test your changes?
Tested changes in sample app.

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript